### PR TITLE
Derive the payment due date once

### DIFF
--- a/src/Entity/InvoiceSettingsData.php
+++ b/src/Entity/InvoiceSettingsData.php
@@ -336,6 +336,24 @@ class InvoiceSettingsData
         return $this;
     }
 
+    /**
+     * The day payment falls due for an invoice issued on the given date.
+     *
+     * Null when this issuer states no payment period: the settings accept free-text
+     * terms instead, and validation only insists that one of the two is filled. A
+     * caller that prints the date has to leave it out in that case rather than
+     * inventing one.
+     */
+    public function dueDateFor(\DateTimeInterface $invoiceDate): ?\DateTimeImmutable
+    {
+        if (null === $this->paymentDueDays) {
+            return null;
+        }
+
+        return \DateTimeImmutable::createFromInterface($invoiceDate)
+            ->modify('+'.$this->paymentDueDays.' days');
+    }
+
     public function getEinvoiceProfile(): ?string
     {
         return $this->einvoiceProfile;

--- a/src/Form/InvoiceSettingsType.php
+++ b/src/Form/InvoiceSettingsType.php
@@ -306,7 +306,10 @@ class InvoiceSettingsType extends AbstractType
     // Ensures either payment terms or payment due days is set.
     public function validatePaymentTerms(InvoiceSettingsData $settings, ExecutionContextInterface $context): void
     {
-        if (empty($settings->getPaymentDueDays()) && empty($settings->getPaymentTerms())) {
+        // Explicitly null, not empty(): a payment period of zero days is a legitimate
+        // setting - due on the invoice date - and empty() would read it as unset and
+        // refuse the save.
+        if (null === $settings->getPaymentDueDays() && empty($settings->getPaymentTerms())) {
             $context->buildViolation('invoice.settings.paymentterm.error')
                 ->atPath('paymentDueDays')
                 ->setTranslationDomain('messages')

--- a/src/Service/EInvoice/ZugferdInvoiceGenerator.php
+++ b/src/Service/EInvoice/ZugferdInvoiceGenerator.php
@@ -110,11 +110,9 @@ class ZugferdInvoiceGenerator
             $mandateReference = $invoice->getMandateReference();
         }
 
-        // payment terms and due date
-        $dueDate = !is_null($settings->getPaymentDueDays())
-            ? (clone $invoice->getDate())->modify('+'.$settings->getPaymentDueDays().' days')
-            : null;
-        $documentBuilder->addDocumentPaymentTerm($settings->getPaymentTerms(), $dueDate, $mandateReference); // Payment term
+        // payment terms and due date - the same date the invoice template prints,
+        // so the XML and the paper never state different deadlines
+        $documentBuilder->addDocumentPaymentTerm($settings->getPaymentTerms(), $settings->dueDateFor($invoice->getDate()), $mandateReference); // Payment term
         // Buyer reference (BT-10, Leitweg-ID): mandatory for XRechnung via validator, omitted otherwise.
         $buyerReference = $invoice->getBuyerReference();
         if (null !== $buyerReference && '' !== trim($buyerReference)) {

--- a/src/Service/InvoiceService.php
+++ b/src/Service/InvoiceService.php
@@ -28,6 +28,7 @@ use App\Entity\Subsidiary;
 use App\Entity\Template;
 use App\Entity\Enum\InvoiceStatus;
 use App\Service\EInvoice\EInvoiceExportService;
+use App\Service\EInvoice\EInvoiceReadinessService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -52,6 +53,9 @@ class InvoiceService
         private readonly AppSettingsService $appSettingsService,
         private readonly ?TouristTaxService $touristTaxService = null,
         private readonly ?InvoiceNumberGenerator $numberGenerator = null,
+        // Optional like the two above, so the unit tests that build this service by
+        // hand keep working; templates then see a null due date.
+        private readonly ?EInvoiceReadinessService $readinessService = null,
     ) {
     }
 
@@ -245,6 +249,9 @@ class InvoiceService
             'numbers' => $appartmentNumbers,
             'appartmentTotal' => number_format($appartmantTotal, 2, ',', '.'),
             'miscTotal' => number_format($miscTotal, 2, ',', '.'),
+            // Issuer data follows the invoice's branch, so a two-company setup prints
+            // each invoice's own payment period. Null when none is configured.
+            'paymentDueDate' => $this->readinessService?->resolveSettingsFor($invoice)?->dueDateFor($invoice->getDate()),
         ];
 
         return $params;

--- a/src/Service/TemplatePreview/InvoiceTemplatePreviewProvider.php
+++ b/src/Service/TemplatePreview/InvoiceTemplatePreviewProvider.php
@@ -113,6 +113,7 @@ class InvoiceTemplatePreviewProvider implements ITemplatePreviewProvider
             'numbers' => ['type' => 'array'],
             'appartmentTotal' => ['type' => 'scalar'],
             'miscTotal' => ['type' => 'scalar'],
+            'paymentDueDate' => ['type' => 'date'],
         ];
     }
 
@@ -253,6 +254,13 @@ class InvoiceTemplatePreviewProvider implements ITemplatePreviewProvider
                 'content' => "<div data-if=\"payment_qr(invoice)\"><img src=\"[[ payment_qr(invoice, 300) ]]\" alt=\"\" width=\"30mm\"></div>",
             ],
             [
+                'id' => 'invoice.payment_due_date',
+                'label' => 'templates.editor.payment_due_date',
+                'group' => 'Invoice',
+                'complexity' => 'easy',
+                'content' => "<p data-if=\"paymentDueDate\">{{ 'invoice.payment_due_date'|trans }}: [[ paymentDueDate|date('d.m.Y') ]]</p>",
+            ],
+            [
                 'id' => 'pdf.header',
                 'label' => 'templates.preview.snippet.pdf_header',
                 'group' => 'PDF',
@@ -340,6 +348,9 @@ class InvoiceTemplatePreviewProvider implements ITemplatePreviewProvider
             'numbers' => $numbers,
             'appartmentTotal' => number_format($appartmentTotal, 2, ',', '.'),
             'miscTotal' => number_format($miscTotal, 2, ',', '.'),
+            // A sample invoice has no issuer behind it, so the preview shows what a
+            // ten-day period would look like rather than leaving the line empty.
+            'paymentDueDate' => (new \DateTimeImmutable('today'))->modify('+10 days'),
         ];
 
         return $this->appendPreviewMeta($params, $ctx);

--- a/tests/Functional/InvoiceSettingsSaveTest.php
+++ b/tests/Functional/InvoiceSettingsSaveTest.php
@@ -232,6 +232,43 @@ final class InvoiceSettingsSaveTest extends WebTestCase
         );
     }
 
+    /**
+     * Zero days is a payment period, not a missing one: the invoice is due on the day
+     * it is issued. The rule asking for terms or a period has to read it as filled,
+     * or that setting cannot be saved without also inventing a terms text.
+     */
+    public function testAPaymentPeriodOfZeroDaysCanBeSaved(): void
+    {
+        $client = static::createClient();
+        $client->loginUser($this->createInvoiceUser());
+
+        $em = static::getContainer()->get(ManagerRegistry::class)->getManager();
+        foreach ($em->getRepository(InvoiceSettingsData::class)->findAll() as $existing) {
+            $em->remove($existing);
+        }
+        $em->flush();
+
+        $setting = $this->buildSetting('en16931', true);
+        $setting->setPaymentTerms(null);
+        $em->persist($setting);
+        $em->flush();
+        $settingId = $setting->getId();
+
+        $crawler = $client->request('GET', '/invoices/settings');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form#sttings-form-1')->form();
+        $form['invoice_settings[paymentDueDays]'] = '0';
+        $form['invoice_settings[paymentTerms]'] = '';
+        $client->submit($form);
+
+        self::assertResponseIsSuccessful();
+
+        $em->clear();
+        $reloaded = $em->getRepository(InvoiceSettingsData::class)->find($settingId);
+        self::assertSame(0, $reloaded->getPaymentDueDays(), 'A payment period of zero days must survive the save');
+    }
+
     private function buildSetting(string $profile, bool $active): InvoiceSettingsData
     {
         $settings = new InvoiceSettingsData();

--- a/tests/Unit/InvoiceSettingsDueDateTest.php
+++ b/tests/Unit/InvoiceSettingsDueDateTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Entity\InvoiceSettingsData;
+use PHPUnit\Framework\TestCase;
+
+final class InvoiceSettingsDueDateTest extends TestCase
+{
+    public function testTheDueDateIsTheInvoiceDatePlusThePaymentPeriod(): void
+    {
+        $settings = (new InvoiceSettingsData())->setPaymentDueDays(10);
+
+        $due = $settings->dueDateFor(new \DateTime('2026-08-27'));
+
+        self::assertSame('2026-09-06', $due?->format('Y-m-d'));
+    }
+
+    /**
+     * The settings accept free-text terms instead of a period, and validation only
+     * insists that one of the two is filled. Callers print nothing rather than a
+     * date they made up.
+     */
+    public function testNoDueDateWithoutAPaymentPeriod(): void
+    {
+        $settings = new InvoiceSettingsData();
+
+        self::assertNull($settings->dueDateFor(new \DateTime('2026-08-27')));
+    }
+
+    public function testAPeriodOfZeroDaysMeansTheInvoiceDateItself(): void
+    {
+        $settings = (new InvoiceSettingsData())->setPaymentDueDays(0);
+
+        self::assertSame('2026-08-27', $settings->dueDateFor(new \DateTime('2026-08-27'))?->format('Y-m-d'));
+    }
+
+    /** Crossing a month and a leap day is date arithmetic, not addition. */
+    public function testThePeriodCrossesMonthBoundaries(): void
+    {
+        $settings = (new InvoiceSettingsData())->setPaymentDueDays(14);
+
+        self::assertSame('2028-03-06', $settings->dueDateFor(new \DateTime('2028-02-21'))?->format('Y-m-d'));
+    }
+
+    /** The invoice keeps its own date; the caller may hold a mutable one. */
+    public function testTheInvoiceDateIsNotModified(): void
+    {
+        $invoiceDate = new \DateTime('2026-08-27');
+        (new InvoiceSettingsData())->setPaymentDueDays(10)->dueDateFor($invoiceDate);
+
+        self::assertSame('2026-08-27', $invoiceDate->format('Y-m-d'));
+    }
+}

--- a/translations/Invoices/messages.de.xlf
+++ b/translations/Invoices/messages.de.xlf
@@ -742,6 +742,10 @@
                 <source>invoice.payment_qr.remittance</source>
                 <target>Rechnung %number%</target>
             </trans-unit>
+            <trans-unit id="invoice.payment_due_date">
+                <source>invoice.payment_due_date</source>
+                <target>Zahlbar bis</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/Invoices/messages.en.yaml
+++ b/translations/Invoices/messages.en.yaml
@@ -186,3 +186,4 @@ invoice.tourist_tax.position.nights: '{0} %count% nights|{1} %count% night|]1,In
 invoice.tourist_tax.position.persons: '{0} %count% people|{1} %count% person|]1,Inf] %count% people'
 invoice.tourist_tax.no_positions: No tourist tax lines were calculated for this booking.
 invoice.payment_qr.remittance: Invoice %number%
+invoice.payment_due_date: Payable by

--- a/translations/Templates/messages.de.xlf
+++ b/translations/Templates/messages.de.xlf
@@ -838,6 +838,14 @@
                 <source>templates.editor.payment_qr.desc</source>
                 <target>Fügt einen QR-Code ein, der in der Banking-App des Zahlenden eine SEPA-Überweisung vorausfüllt. Die Zahl ist die Auflösung des Bildes in Pixeln; wie groß es auf der Seite erscheint, bestimmt die Breite des Bildes, die du am Ziehpunkt einstellst. Der Code erscheint nur, wenn in den Rechnungseinstellungen eine Bankverbindung hinterlegt ist und die Installation in Euro rechnet.</target>
             </trans-unit>
+            <trans-unit id="templates.editor.payment_due_date">
+                <source>templates.editor.payment_due_date</source>
+                <target>Fälligkeitsdatum</target>
+            </trans-unit>
+            <trans-unit id="templates.editor.payment_due_date.desc">
+                <source>templates.editor.payment_due_date.desc</source>
+                <target>Fügt den Tag ein, an dem die Zahlung fällig wird. Er stammt aus dem Zahlungsziel in den Rechnungseinstellungen, damit gedrucktes Datum und E-Rechnung nie auseinanderlaufen. Ist dort kein Zahlungsziel hinterlegt, entfällt die Zeile.</target>
+            </trans-unit>
             <trans-unit id="templates.notfound">
                 <source>templates.notfound</source>
                 <target>Es konnte keine Vorlage gefunden werden. Stelle bitte sicher, dass ein Template für die ausgewählte Aktion existiert.</target>

--- a/translations/Templates/messages.en.yaml
+++ b/translations/Templates/messages.en.yaml
@@ -80,6 +80,11 @@ templates.editor.payment_qr.desc: >-
   page is the image's own width, which the resize handle sets. The code only
   appears when the bank details are configured in the invoice settings and the
   installation runs in euro.
+templates.editor.payment_due_date: Payment due date
+templates.editor.payment_due_date.desc: >-
+  Inserts the day payment falls due, taken from the payment period in the
+  invoice settings so the printed date and the e-invoice always agree. The line
+  is left out when the settings state no period.
 templates.editor.tourist_tax.positions.desc: >-
   Inserts a table with all tourist-tax / accommodation-tax positions. The
   table is only rendered when such positions exist on the invoice.


### PR DESCRIPTION
https://github.com/developeregrem/fewohbee/discussions/273#discussioncomment-18096770

The date a payment falls due was worked out in two places: inside the e-invoice
generator for the XML, and — for anyone wanting it on the printed invoice — a
second time by hand in the template, as invoice date plus ten days typed there.
Change the payment period in the settings and the XML moves while the paper
stays where it was.

## One derivation

It now lives on the settings that carry the period:

```php
public function dueDateFor(\DateTimeInterface $invoiceDate): ?\DateTimeImmutable
```

Both callers ask them — the generator for the XML, and the new template
parameter `paymentDueDate` for the printed page. The generator needed no new
dependency: it already had the settings in hand and only lost its inline
expression.

The issuer is resolved through `EInvoiceReadinessService::resolveSettingsFor()`,
so a two-company setup prints each invoice's own payment period rather than
whichever row is globally active — the same resolution the invoice export
already uses.

## When no period is configured

`null`, and the snippet guards with `data-if`. The settings accept free-text
payment terms instead of a period, and validation only insists that one of the
two is filled, so an invoice legitimately has no due date. A missing line beats
an invented one.

## In the editor

`paymentDueDate` is in the render params schema, so autocomplete offers it, and
there is a snippet in the insert list:

```html
<p data-if="paymentDueDate">{{ 'invoice.payment_due_date'|trans }}: [[ paymentDueDate|date('d.m.Y') ]]</p>
```

Label and snippet description are translated in both languages.

## Tests

Five unit tests on the derivation: the ordinary case, a missing period, a period
of zero days, a span crossing a month boundary over a leap day, and that the
invoice's own date is not modified in passing. The existing e-invoice tests
cover the generator that now calls it — 31 unit and 13 functional, unchanged and
green.

## Two things you may want differently

**The name.** `paymentDueDate` next to the existing `invoice.date`, or shorter
`dueDate`? I went with the longer one because in an invoice template it is
otherwise unclear whose deadline is meant.

**The label.** The snippet prints `invoice.payment_due_date`, "Zahlbar bis" /
"Payable by". If you would rather have the wording live in the template than in
a translation key, the snippet can just as well carry plain text.
