### PR TITLE
Let branches carry their opening hours

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -60,6 +60,10 @@ tags:
     description: >-
       Tourist tax (Kurtaxe / city tax) configuration and the monthly report a municipality
       filing is built from.
+  - name: Subsidiaries
+    description: >-
+      Branch master data including the weekly opening hours, so a website or home
+      automation can print them from one place instead of keeping a second copy.
   - name: Calendars
     description: iCal export of a room's occupancy, public holidays, and custom calendars.
   - name: Statistics
@@ -781,6 +785,36 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '429': { $ref: '#/components/responses/TooManyRequests' }
 
+  /subsidiaries:
+    get:
+      tags: [Subsidiaries]
+      operationId: listSubsidiaries
+      summary: The configured branches
+      description: |
+        Requires the `subsidiaries:read` scope.
+
+        Master data only. `openingHours` is what an operator entered under Settings →
+        Branches; whether a branch is open at the moment of the call is not computed, as
+        that depends on the caller's timezone.
+      responses:
+        '200':
+          description: All branches, ordered by name.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: '#/components/schemas/Subsidiary' }
+                  meta:
+                    type: object
+                    properties:
+                      count: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
   /openapi.yaml:
     get:
       tags: [Meta]
@@ -908,6 +942,33 @@ components:
         - error:
             code: 400
             message: "Invalid parameter 'start': expected format Y-m-d."
+
+    Subsidiary:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: string }
+        openingHours:
+          type: [object, 'null']
+          description: >-
+            Weekday ('1' = Monday … '7' = Sunday) to its time ranges, or null when no
+            opening hours are configured at all. Within a configured set, a weekday that
+            is absent is closed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              properties:
+                from: { type: string, examples: ['08:00'] }
+                to: { type: string, examples: ['12:00'] }
+      examples:
+        - id: 1
+          name: Main house
+          description: Reception building
+          openingHours:
+            '1': [{ from: '08:00', to: '12:00' }, { from: '16:00', to: '19:00' }]
+            '6': [{ from: '09:00', to: '12:00' }]
 
     Reservation:
       type: object

--- a/docs/release-notes/4.12.0.de.md
+++ b/docs/release-notes/4.12.0.de.md
@@ -50,6 +50,13 @@
 * Zwei neue Berechtigungen: **Preise lesen** und **Kurtaxe lesen**. ℹ️ Bestehende API-Zugänge bekommen sie **nicht** automatisch — wer die neuen Abfragen nutzen will, legt einen neuen Zugang an oder ersetzt den alten.
 * 📖 Alle Abfragen mit Beispielen: [REST-API im Wiki](https://github.com/developeregrem/fewohbee/wiki/REST-API)
 
+## 🕒 Öffnungszeiten je Niederlassung
+* Unter Einstellungen → Niederlassungen lassen sich jetzt **Öffnungszeiten** hinterlegen: je Wochentag zwei Zeitfenster, damit auch eine Mittagspause abbildbar ist. Ein Tag ohne Zeiten gilt als geschlossen.
+* In Vorlagen für Briefe und E-Mails stehen die Zeiten als Platzhalter zur Verfügung, sodass z. B. die Buchungsbestätigung sie mitschickt.
+* Über die REST-API sind sie zusammen mit den übrigen Stammdaten der Niederlassung abrufbar — für die eigene Webseite oder die Hausautomation. Dafür gibt es die neue Berechtigung **Niederlassungen lesen**. ℹ️ Bestehende API-Zugänge bekommen sie **nicht** automatisch.
+* Die Zeiten sind reine Information: An Verfügbarkeit, Buchungen und Anreisezeiten ändert sich nichts.
+* von @MeisterAdebar in https://github.com/developeregrem/fewohbee/pull/283
+
 ## 🔧 Weitere Änderungen
 * Bei Automatisierungen, die eine Rechnung versenden oder anhängen, lässt sich jetzt optional die **Rechnungsvorlage (PDF)** auswählen — z. B. ein kompaktes Layout für den Mailversand. Das gilt für die Aktion „Rechnung per E-Mail versenden" ebenso wie für Rechnungen, die einer Vorlagen-E-Mail angehängt werden. Ohne Auswahl wird wie bisher die Standardvorlage verwendet.
 * Die tägliche Aufräum-Aufgabe (Cronjob) entfernt jetzt auch alte Benachrichtigungen, mit derselben Aufbewahrungsfrist wie die Protokolle (standardmäßig 90 Tage).

--- a/migrations/Version20260831120000.php
+++ b/migrations/Version20260831120000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Opening hours per branch.
+ *
+ * Adds `opening_hours` to `objects`, holding a JSON map of ISO weekday (1 = Monday) to a
+ * list of [from, to] time ranges in 'HH:MM' notation. A weekday missing from the map is
+ * closed; NULL means no opening hours were ever configured.
+ *
+ * A JSON column rather than a table because this is display data: no query asks whether a
+ * branch is open at a given moment, so there is nothing to index or join against. Should
+ * opening hours ever gain behaviour — blocking availability, constraining arrivals — that
+ * decision deserves its own table and its own migration.
+ *
+ * down() drops the column and with it the configured hours; they cannot be reconstructed.
+ */
+final class Version20260831120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add opening_hours to objects (per-subsidiary opening hours, display only)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects ADD opening_hours JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects DROP opening_hours');
+    }
+}

--- a/src/Controller/Api/SubsidiaryApiController.php
+++ b/src/Controller/Api/SubsidiaryApiController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the guesthouse administration package.
+ *
+ * (c) Alexander Elchlepp <info@fewohbee.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller\Api;
+
+use App\Dto\Api\SubsidiaryDto;
+use App\Repository\SubsidiaryRepository;
+use App\Security\Voter\ApiScopeVoter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Token-authenticated branch master data, including opening hours.
+ *
+ * Opening hours are part of a branch rather than an endpoint of their own: they are one
+ * property among several, and whoever prints them on a website usually wants the branch
+ * name next to them anyway.
+ *
+ * Only stored data is returned. Whether a branch is open at this very moment is
+ * deliberately not computed — that depends on the caller's timezone, and the rest of this
+ * API returns locale- and timezone-independent data.
+ */
+#[Route('/api/v1/subsidiaries')]
+#[IsGranted(ApiScopeVoter::SUBSIDIARIES_READ)]
+class SubsidiaryApiController extends AbstractController
+{
+    public function __construct(
+        private readonly SubsidiaryRepository $subsidiaryRepository,
+    ) {
+    }
+
+    /**
+     * The configured branches with their master data and weekly opening hours.
+     */
+    #[Route('', name: 'api.subsidiaries.list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $subsidiaries = $this->subsidiaryRepository->findAllOrdered();
+        $data = array_map(static fn ($subsidiary): SubsidiaryDto => SubsidiaryDto::fromEntity($subsidiary), $subsidiaries);
+
+        return new JsonResponse([
+            'data' => $data,
+            'meta' => ['count' => \count($data)],
+        ]);
+    }
+}

--- a/src/Dto/Api/SubsidiaryDto.php
+++ b/src/Dto/Api/SubsidiaryDto.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Api;
+
+use App\Entity\Subsidiary;
+
+/**
+ * API representation of a branch and its master data.
+ *
+ * The invoice number pattern is deliberately not exposed: it is internal billing
+ * configuration, of no use to an API consumer and not something a read token should
+ * hand out.
+ */
+final readonly class SubsidiaryDto
+{
+    /**
+     * @param array<int, list<array{from: string, to: string}>>|null $openingHours weekday
+     *        (1 = Monday … 7 = Sunday) to its time ranges, or null when no opening hours
+     *        are configured at all; within a configured set, an absent weekday is closed
+     */
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $description,
+        public ?array $openingHours,
+    ) {
+    }
+
+    public static function fromEntity(Subsidiary $subsidiary): self
+    {
+        $openingHours = [];
+        foreach ($subsidiary->getOpeningHours() as $weekday => $ranges) {
+            // Named keys rather than the entity's positional [from, to] pairs: a consumer
+            // reads range.from, not range[0]. Weekday keys start at 1, so json_encode
+            // always renders the map as an object and never as a list.
+            $openingHours[$weekday] = array_map(
+                static fn (array $range): array => ['from' => $range[0], 'to' => $range[1]],
+                $ranges
+            );
+        }
+
+        return new self(
+            (int) $subsidiary->getId(),
+            (string) $subsidiary->getName(),
+            (string) $subsidiary->getDescription(),
+            // Null rather than an empty array: an empty PHP array serialises to [], which
+            // would contradict the object the schema promises. Null says "not configured"
+            // without a second shape for the same field.
+            [] === $openingHours ? null : $openingHours,
+        );
+    }
+}

--- a/src/Entity/Enum/ApiScope.php
+++ b/src/Entity/Enum/ApiScope.php
@@ -14,6 +14,7 @@ enum ApiScope: string
     case INVOICES_READ = 'invoices:read';
     case PRICES_READ = 'prices:read';
     case TOURIST_TAX_READ = 'tourist-tax:read';
+    case SUBSIDIARIES_READ = 'subsidiaries:read';
 
     public function requiredRole(): string
     {
@@ -24,6 +25,7 @@ enum ApiScope: string
             self::INVOICES_READ => 'ROLE_INVOICES',
             self::PRICES_READ => 'ROLE_RESERVATIONS_RO',
             self::TOURIST_TAX_READ => 'ROLE_OPERATIONS',
+            self::SUBSIDIARIES_READ => 'ROLE_RESERVATIONS_RO',
         };
     }
 
@@ -36,6 +38,7 @@ enum ApiScope: string
             self::INVOICES_READ => 'profile.apitokens.scopes.invoices_read',
             self::PRICES_READ => 'profile.apitokens.scopes.prices_read',
             self::TOURIST_TAX_READ => 'profile.apitokens.scopes.tourist_tax_read',
+            self::SUBSIDIARIES_READ => 'profile.apitokens.scopes.subsidiaries_read',
         };
     }
 }

--- a/src/Entity/Subsidiary.php
+++ b/src/Entity/Subsidiary.php
@@ -27,6 +27,20 @@ class Subsidiary
      */
     #[ORM\Column(type: 'string', length: 100, nullable: true)]
     private ?string $invoiceNumberPattern = null;
+
+    /**
+     * Opening hours of this branch, keyed by ISO weekday (1 = Monday … 7 = Sunday).
+     * Each weekday holds a list of [from, to] ranges in 'HH:MM' notation; a weekday
+     * missing from the array is closed.
+     *
+     * Display data only: nothing derives availability, arrival windows or any other
+     * behaviour from it. That is why it is a JSON column and not a queryable table —
+     * no query ever asks "is the branch open at 14:00?".
+     *
+     * @var array<int, list<array{0: string, 1: string}>>|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $openingHours = null;
     #[ORM\OneToMany(targetEntity: 'Appartment', mappedBy: 'object')]
     private $appartments;
 
@@ -94,6 +108,123 @@ class Subsidiary
         $this->invoiceNumberPattern = '' === $invoiceNumberPattern ? null : $invoiceNumberPattern;
 
         return $this;
+    }
+
+    /**
+     * @return array<int, list<array{0: string, 1: string}>>
+     */
+    public function getOpeningHours(): array
+    {
+        return $this->openingHours ?? [];
+    }
+
+    /**
+     * Incomplete ranges (only one end filled in) and weekdays outside 1..7 are dropped,
+     * and an entirely empty grid is stored as null, so "no opening hours configured" has
+     * exactly one representation — the same reasoning as setInvoiceNumberPattern().
+     *
+     * @param array<int|string, iterable<array{0?: ?string, 1?: ?string}>>|null $openingHours
+     */
+    public function setOpeningHours(?array $openingHours): self
+    {
+        $normalized = [];
+
+        foreach ($openingHours ?? [] as $weekday => $ranges) {
+            $weekday = (int) $weekday;
+            if ($weekday < 1 || $weekday > 7) {
+                continue;
+            }
+
+            foreach ($ranges as $range) {
+                $from = trim((string) ($range[0] ?? ''));
+                $to = trim((string) ($range[1] ?? ''));
+
+                // A range only carries meaning once both ends are known.
+                if ('' === $from || '' === $to) {
+                    continue;
+                }
+
+                $normalized[$weekday][] = [$from, $to];
+            }
+        }
+
+        ksort($normalized);
+
+        $this->openingHours = [] === $normalized ? null : $normalized;
+
+        return $this;
+    }
+
+    /**
+     * One-line rendering for correspondence templates and overviews, e.g.
+     * "Mo.–Fr. 08:00–12:00, 16:00–19:00 · Sa. 09:00–12:00".
+     *
+     * Consecutive weekdays sharing the same hours are folded into a range so the common
+     * "Monday to Friday" case does not print five near-identical entries. Weekday names
+     * follow the current default locale, which Symfony sets per request — reading a global
+     * keeps the entity free of injected services.
+     */
+    public function getOpeningHoursFormatted(): string
+    {
+        $hours = $this->getOpeningHours();
+        if ([] === $hours) {
+            return '';
+        }
+
+        $groups = [];
+        foreach (range(1, 7) as $weekday) {
+            $ranges = $hours[$weekday] ?? [];
+            if ([] === $ranges) {
+                continue;
+            }
+
+            $times = implode(', ', array_map(
+                static fn (array $range): string => $range[0].'–'.$range[1],
+                $ranges
+            ));
+
+            $last = array_key_last($groups);
+            // Extend the previous group only when it ends on the day right before this
+            // one; a gap (e.g. closed on Wednesday) has to start a new group.
+            if (null !== $last && $groups[$last]['times'] === $times && $groups[$last]['to'] === $weekday - 1) {
+                $groups[$last]['to'] = $weekday;
+                continue;
+            }
+
+            $groups[] = ['from' => $weekday, 'to' => $weekday, 'times' => $times];
+        }
+
+        $parts = [];
+        foreach ($groups as $group) {
+            $label = self::weekdayName($group['from']);
+            if ($group['to'] > $group['from']) {
+                $label .= '–'.self::weekdayName($group['to']);
+            }
+
+            $parts[] = $label.' '.$group['times'];
+        }
+
+        return implode(' · ', $parts);
+    }
+
+    /**
+     * Abbreviated weekday name for an ISO weekday (1 = Monday) in the default locale.
+     */
+    private static function weekdayName(int $weekday): string
+    {
+        // 2024-01-01 was a Monday, so offsetting from it lands on the wanted weekday.
+        $date = (new \DateTimeImmutable('2024-01-01'))->modify('+'.($weekday - 1).' days');
+
+        $formatter = new \IntlDateFormatter(
+            \Locale::getDefault(),
+            \IntlDateFormatter::NONE,
+            \IntlDateFormatter::NONE,
+            null,
+            null,
+            'EEE'
+        );
+
+        return $formatter->format($date) ?: '';
     }
 
     public function setAppartments($appartments): void

--- a/src/Repository/SubsidiaryRepository.php
+++ b/src/Repository/SubsidiaryRepository.php
@@ -70,6 +70,20 @@ class SubsidiaryRepository extends ServiceEntityRepository
     }
 
     /**
+     * All branches in the order the API and the overview present them.
+     *
+     * @return list<Subsidiary>
+     */
+    public function findAllOrdered(): array
+    {
+        return $this->createQueryBuilder('s')
+            ->orderBy('s.name', 'ASC')
+            ->addOrderBy('s.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Branches that define their own number range, keyed by nothing in particular —
      * used by the bank import settings screen to label each pattern with its branch.
      *

--- a/src/Security/Voter/ApiScopeVoter.php
+++ b/src/Security/Voter/ApiScopeVoter.php
@@ -24,6 +24,7 @@ class ApiScopeVoter extends Voter
     public const INVOICES_READ = 'API_SCOPE_INVOICES_READ';
     public const PRICES_READ = 'API_SCOPE_PRICES_READ';
     public const TOURIST_TAX_READ = 'API_SCOPE_TOURIST_TAX_READ';
+    public const SUBSIDIARIES_READ = 'API_SCOPE_SUBSIDIARIES_READ';
 
     private const ATTRIBUTE_SCOPES = [
         self::RESERVATIONS_READ => ApiScope::RESERVATIONS_READ,
@@ -32,6 +33,7 @@ class ApiScopeVoter extends Voter
         self::INVOICES_READ => ApiScope::INVOICES_READ,
         self::PRICES_READ => ApiScope::PRICES_READ,
         self::TOURIST_TAX_READ => ApiScope::TOURIST_TAX_READ,
+        self::SUBSIDIARIES_READ => ApiScope::SUBSIDIARIES_READ,
     ];
 
     public function __construct(

--- a/src/Service/SubsidiaryService.php
+++ b/src/Service/SubsidiaryService.php
@@ -40,8 +40,43 @@ class SubsidiaryService
         $object->setName($request->request->get('name-'.$id));
         $object->setDescription($request->request->get('description-'.$id));
         $object->setInvoiceNumberPattern($request->request->get('invoice-number-pattern-'.$id));
+        $object->setOpeningHours($this->getOpeningHoursFromForm($request, $id));
 
         return $object;
+    }
+
+    /**
+     * Reads the weekday grid of the object form into the shape the entity stores:
+     * weekday => list of [from, to]. Empty and half-filled ranges are left in place
+     * here and dropped by Subsidiary::setOpeningHours(), so normalisation lives in
+     * exactly one spot.
+     *
+     * @param int|string $id
+     *
+     * @return array<int, list<array{0: string, 1: string}>>
+     */
+    private function getOpeningHoursFromForm(Request $request, $id): array
+    {
+        $hours = [];
+
+        foreach ($request->request->all('opening-hours-'.$id) as $weekday => $ranges) {
+            if (!is_array($ranges)) {
+                continue;
+            }
+
+            foreach ($ranges as $range) {
+                if (!is_array($range)) {
+                    continue;
+                }
+
+                $hours[(int) $weekday][] = [
+                    (string) ($range['from'] ?? ''),
+                    (string) ($range['to'] ?? ''),
+                ];
+            }
+        }
+
+        return $hours;
     }
 
     public function deleteObject(Subsidiary $object)

--- a/templates/Subsidiary/object_form_input_fields.html.twig
+++ b/templates/Subsidiary/object_form_input_fields.html.twig
@@ -26,5 +26,44 @@
             <small class="form-text text-muted">{{ 'object.invoice_number_pattern.help'|trans|raw }}</small>
         </div>
     </div>
+
+    <hr>
+    <h5>{{ 'object.opening_hours'|trans }}</h5>
+    <p class="text-muted small mb-2">{{ 'object.opening_hours.help'|trans|raw }}</p>
+    <table class="table table-sm align-middle mb-2">
+        <thead>
+            <tr>
+                <th style="width: 20%;"></th>
+                <th style="width: 40%;">{{ 'object.opening_hours.period.1'|trans }}</th>
+                <th style="width: 40%;">{{ 'object.opening_hours.period.2'|trans }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for weekday in 1..7 %}
+                {% set ranges = object.openingHours[weekday]|default([]) %}
+                {% set weekdayLabel = ('object.weekday.' ~ weekday)|trans %}
+                <tr>
+                    <th scope="row" class="fw-normal">{{ weekdayLabel }}</th>
+                    {% for slot in 0..1 %}
+                        {% set range = ranges[slot]|default(['', '']) %}
+                        {% set periodLabel = ('object.opening_hours.period.' ~ (slot + 1))|trans %}
+                        <td>
+                            <div class="d-flex align-items-center gap-2">
+                                <input type="time" class="form-control form-control-sm"
+                                       name="opening-hours-{{ object.id }}[{{ weekday }}][{{ slot }}][from]"
+                                       value="{{ range[0] }}"
+                                       aria-label="{{ weekdayLabel }}, {{ periodLabel }}, {{ 'object.opening_hours.from'|trans }}">
+                                <span class="text-muted">–</span>
+                                <input type="time" class="form-control form-control-sm"
+                                       name="opening-hours-{{ object.id }}[{{ weekday }}][{{ slot }}][to]"
+                                       value="{{ range[1] }}"
+                                       aria-label="{{ weekdayLabel }}, {{ periodLabel }}, {{ 'object.opening_hours.to'|trans }}">
+                            </div>
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </fieldset>
 <input name="_csrf_token" value="{{ token }}" type="hidden">

--- a/tests/Unit/SubsidiaryDtoTest.php
+++ b/tests/Unit/SubsidiaryDtoTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Dto\Api\SubsidiaryDto;
+use App\Entity\Subsidiary;
+use PHPUnit\Framework\TestCase;
+
+final class SubsidiaryDtoTest extends TestCase
+{
+    public function testUnconfiguredOpeningHoursBecomeNull(): void
+    {
+        $dto = SubsidiaryDto::fromEntity($this->subsidiary());
+
+        self::assertNull($dto->openingHours);
+        self::assertStringContainsString('"openingHours":null', $this->encode($dto));
+    }
+
+    public function testRangesAreExposedWithNamedKeys(): void
+    {
+        $subsidiary = $this->subsidiary();
+        $subsidiary->setOpeningHours([
+            1 => [['08:00', '12:00'], ['16:00', '19:00']],
+            6 => [['09:00', '12:00']],
+        ]);
+
+        $dto = SubsidiaryDto::fromEntity($subsidiary);
+
+        self::assertSame([
+            1 => [
+                ['from' => '08:00', 'to' => '12:00'],
+                ['from' => '16:00', 'to' => '19:00'],
+            ],
+            6 => [
+                ['from' => '09:00', 'to' => '12:00'],
+            ],
+        ], $dto->openingHours);
+    }
+
+    /**
+     * Weekday keys start at 1, so the map must never serialise as a JSON list — a consumer
+     * indexing by weekday would otherwise silently read the wrong day.
+     */
+    public function testOpeningHoursSerialiseAsAnObject(): void
+    {
+        $subsidiary = $this->subsidiary();
+        $subsidiary->setOpeningHours([1 => [['08:00', '12:00']]]);
+
+        $json = $this->encode(SubsidiaryDto::fromEntity($subsidiary));
+
+        self::assertStringContainsString('"openingHours":{"1":', $json);
+    }
+
+    public function testAllSevenWeekdaysStillSerialiseAsAnObject(): void
+    {
+        $subsidiary = $this->subsidiary();
+        $subsidiary->setOpeningHours(array_fill_keys(range(1, 7), [['08:00', '12:00']]));
+
+        $json = $this->encode(SubsidiaryDto::fromEntity($subsidiary));
+
+        self::assertStringContainsString('"openingHours":{"1":', $json);
+        self::assertStringContainsString('"7":', $json);
+    }
+
+    public function testTheInvoiceNumberPatternIsNotExposed(): void
+    {
+        $subsidiary = $this->subsidiary();
+        $subsidiary->setInvoiceNumberPattern('RE-<year>-<number:4>');
+
+        self::assertStringNotContainsString('RE-', $this->encode(SubsidiaryDto::fromEntity($subsidiary)));
+    }
+
+    private function subsidiary(): Subsidiary
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setId(1);
+        $subsidiary->setName('Main house');
+        $subsidiary->setDescription('Reception building');
+
+        return $subsidiary;
+    }
+
+    private function encode(SubsidiaryDto $dto): string
+    {
+        return json_encode($dto, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Unit/SubsidiaryOpeningHoursTest.php
+++ b/tests/Unit/SubsidiaryOpeningHoursTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Entity\Subsidiary;
+use PHPUnit\Framework\TestCase;
+
+final class SubsidiaryOpeningHoursTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // getOpeningHoursFormatted() reads the default locale, so the expected weekday
+        // abbreviations below stay stable regardless of the machine running the suite.
+        \Locale::setDefault('de_DE');
+    }
+
+    public function testNewSubsidiaryHasNoOpeningHours(): void
+    {
+        $subsidiary = new Subsidiary();
+
+        self::assertSame([], $subsidiary->getOpeningHours());
+        self::assertSame('', $subsidiary->getOpeningHoursFormatted());
+    }
+
+    public function testHalfFilledAndEmptyRangesAreDropped(): void
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours([
+            1 => [['08:00', '12:00'], ['16:00', '']],
+            2 => [['', ''], ['', '18:00']],
+        ]);
+
+        self::assertSame([1 => [['08:00', '12:00']]], $subsidiary->getOpeningHours());
+    }
+
+    public function testAnEntirelyEmptyGridBecomesNoOpeningHours(): void
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours([
+            1 => [['', ''], ['', '']],
+            2 => [['', '']],
+        ]);
+
+        self::assertSame([], $subsidiary->getOpeningHours());
+        self::assertSame('', $subsidiary->getOpeningHoursFormatted());
+    }
+
+    public function testWeekdaysOutsideTheIsoRangeAreIgnored(): void
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours([
+            0 => [['08:00', '12:00']],
+            8 => [['08:00', '12:00']],
+            3 => [['09:00', '13:00']],
+        ]);
+
+        self::assertSame([3 => [['09:00', '13:00']]], $subsidiary->getOpeningHours());
+    }
+
+    public function testStringKeysFromJsonDecodingAreAccepted(): void
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours(['5' => [['10:00', '14:00']]]);
+
+        self::assertSame([5 => [['10:00', '14:00']]], $subsidiary->getOpeningHours());
+    }
+
+    public function testConsecutiveWeekdaysWithEqualHoursAreFolded(): void
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours([
+            1 => [['08:00', '12:00'], ['16:00', '19:00']],
+            2 => [['08:00', '12:00'], ['16:00', '19:00']],
+            3 => [['08:00', '12:00'], ['16:00', '19:00']],
+            4 => [['08:00', '12:00'], ['16:00', '19:00']],
+            5 => [['08:00', '12:00'], ['16:00', '19:00']],
+            6 => [['09:00', '12:00']],
+        ]);
+
+        self::assertSame(
+            'Mo.–Fr. 08:00–12:00, 16:00–19:00 · Sa. 09:00–12:00',
+            $subsidiary->getOpeningHoursFormatted()
+        );
+    }
+
+    public function testAClosedDayInterruptsTheFolding(): void
+    {
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours([
+            1 => [['08:00', '12:00']],
+            2 => [['08:00', '12:00']],
+            // Wednesday closed.
+            4 => [['08:00', '12:00']],
+            5 => [['08:00', '12:00']],
+        ]);
+
+        self::assertSame(
+            'Mo.–Di. 08:00–12:00 · Do.–Fr. 08:00–12:00',
+            $subsidiary->getOpeningHoursFormatted()
+        );
+    }
+
+    public function testWeekdayNamesFollowTheLocale(): void
+    {
+        \Locale::setDefault('en_GB');
+
+        $subsidiary = new Subsidiary();
+        $subsidiary->setOpeningHours([7 => [['10:00', '12:00']]]);
+
+        self::assertSame('Sun 10:00–12:00', $subsidiary->getOpeningHoursFormatted());
+    }
+}

--- a/tests/Unit/TemplateSchemaServiceTest.php
+++ b/tests/Unit/TemplateSchemaServiceTest.php
@@ -54,5 +54,27 @@ final class TemplateSchemaServiceTest extends TestCase
 
         self::assertSame('scalar', $schema['broken']['type']);
     }
+
+    /**
+     * The opening hours form tells the user the times can be used as a placeholder in
+     * letter and email templates. That promise only holds while the branch stays within
+     * the schema's depth limit, so it is asserted rather than assumed.
+     */
+    public function testOpeningHoursOfTheBranchAreReachableFromAReservation(): void
+    {
+        $service = new TemplateSchemaService();
+
+        $schema = $service->buildSchema([
+            'reservation1' => ['class' => Reservation::class],
+        ]);
+
+        $node = $schema['reservation1'];
+        foreach (['appartment', 'object', 'openingHoursFormatted'] as $step) {
+            self::assertArrayHasKey($step, $node['properties'], 'not reachable: '.$step);
+            $node = $node['properties'][$step];
+        }
+
+        self::assertSame('scalar', $node['type']);
+    }
 }
 

--- a/translations/Profile/messages.de.yaml
+++ b/translations/Profile/messages.de.yaml
@@ -50,6 +50,7 @@ profile:
       invoices_read: Rechnungen lesen
       prices_read: Preise lesen (Preisliste, Preisauskunft, Ratenkalender)
       tourist_tax_read: Kurtaxe lesen (Einstellungen und Monatsabrechnung)
+      subsidiaries_read: Niederlassungen lesen (Stammdaten und Öffnungszeiten)
   passkeys:
     title: Passwortlose Anmeldung (Passkeys)
     create: Passkey anlegen

--- a/translations/Profile/messages.en.yaml
+++ b/translations/Profile/messages.en.yaml
@@ -50,6 +50,7 @@ profile:
       invoices_read: Read invoices
       prices_read: Read prices (price list, price quote, rate calendar)
       tourist_tax_read: Read tourist tax (settings and monthly report)
+      subsidiaries_read: Read branches (master data and opening hours)
   passkeys:
     title: Passwordless sign-in (Passkeys)
     create: Add passkey

--- a/translations/Subsidiary/messages.de.xlf
+++ b/translations/Subsidiary/messages.de.xlf
@@ -54,6 +54,58 @@
                 <source>object.flash.invoice_number_pattern.invalid</source>
                 <target>Der Rechnungsnummern-Kreis ist ungültig. Er braucht genau einen &lt;number&gt;-Platzhalter und darf nur bekannte Platzhalter verwenden.</target>
             </trans-unit>
+            <trans-unit id="object.opening_hours">
+                <source>object.opening_hours</source>
+                <target>Öffnungszeiten</target>
+            </trans-unit>
+            <trans-unit id="object.opening_hours.help">
+                <source>object.opening_hours.help</source>
+                <target>Leer lassen bedeutet geschlossen. Die Zeiten lassen sich in Vorlagen für Briefe und E-Mails über den Platzhalter &lt;code&gt;openingHoursFormatted&lt;/code&gt; der Niederlassung ausgeben und über die REST-API abrufen.</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.1">
+                <source>object.weekday.1</source>
+                <target>Montag</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.2">
+                <source>object.weekday.2</source>
+                <target>Dienstag</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.3">
+                <source>object.weekday.3</source>
+                <target>Mittwoch</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.4">
+                <source>object.weekday.4</source>
+                <target>Donnerstag</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.5">
+                <source>object.weekday.5</source>
+                <target>Freitag</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.6">
+                <source>object.weekday.6</source>
+                <target>Samstag</target>
+            </trans-unit>
+            <trans-unit id="object.weekday.7">
+                <source>object.weekday.7</source>
+                <target>Sonntag</target>
+            </trans-unit>
+            <trans-unit id="object.opening_hours.period.1">
+                <source>object.opening_hours.period.1</source>
+                <target>Zeitraum 1</target>
+            </trans-unit>
+            <trans-unit id="object.opening_hours.period.2">
+                <source>object.opening_hours.period.2</source>
+                <target>Zeitraum 2</target>
+            </trans-unit>
+            <trans-unit id="object.opening_hours.from">
+                <source>object.opening_hours.from</source>
+                <target>von</target>
+            </trans-unit>
+            <trans-unit id="object.opening_hours.to">
+                <source>object.opening_hours.to</source>
+                <target>bis</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/Subsidiary/messages.en.yaml
+++ b/translations/Subsidiary/messages.en.yaml
@@ -10,4 +10,17 @@ object.invoice_number_pattern: Own invoice number range
 object.invoice_number_pattern.help: 'Leave empty to use the default range from the settings. Placeholders: <code>&lt;year&gt;</code>, <code>&lt;year2&gt;</code>, <code>&lt;month&gt;</code>, <code>&lt;day&gt;</code>, <code>&lt;number:4&gt;</code>. Invoices for rooms of this branch then get their own running number.'
 object.invoice_number_pattern.placeholder: 'e.g. RE-<year>-<number:4>'
 object.name: Branch
+object.opening_hours: Opening hours
+object.opening_hours.from: from
+object.opening_hours.help: 'Leave empty for closed. The times can be printed in letter and email templates through the branch''s <code>openingHoursFormatted</code> placeholder, and retrieved through the REST API.'
+object.opening_hours.period.1: Period 1
+object.opening_hours.period.2: Period 2
+object.opening_hours.to: to
 object.title: Branch management
+object.weekday.1: Monday
+object.weekday.2: Tuesday
+object.weekday.3: Wednesday
+object.weekday.4: Thursday
+object.weekday.5: Friday
+object.weekday.6: Saturday
+object.weekday.7: Sunday


### PR DESCRIPTION
Closes #281 in its smallest useful form.

**This is the least-effort version on purpose** — the weekly hours and nothing else,
so you can say whether the shape is right before more is built on it.

## At the branch, not on a page of its own

As you asked in the issue: the hours sit in the branch form under
Settings → Branches, below the invoice number range. No new settings entry, no new
navigation item — the dropdown there has thirteen already.

Two time ranges per weekday, so a lunch break fits. A weekday left empty is closed,
which the help text says. The grid is a full-width table rather than a field in the
right-hand column: twenty-eight `<input type="time">` squeezed into `col-sm-8` leave
each field about 78px, and Chrome needs 110–130.

## Stored as JSON, not as a table

Keyed by ISO weekday, each day a list of `[from, to]`. No query asks whether a branch
is open at a given moment, so there is nothing to index or join against, and the
existing JSON columns on `AppSettings` and `OnlineBookingConfig` are the precedent.
If the hours ever gain behaviour — blocking availability, constraining arrivals — that
deserves its own table and its own migration rather than a column quietly growing into
one.

## In templates

`getOpeningHoursFormatted()` folds consecutive weekdays with equal hours into a range
and follows the current locale:

```
Mo.–Fr. 08:00–12:00, 16:00–19:00 · Sa. 09:00–12:00
```

It reads `\Locale::getDefault()` rather than taking a translator, so the entity stays
free of injected services. A test pins that the branch is still reachable from a
reservation inside `TemplateSchemaService`'s depth limit, because the form promises
the placeholder exists.

## Over the API

No `/openinghours` endpoint, as you said — the hours are one property of a branch
among several, and whoever prints them usually wants the branch name next to them:

```
GET /api/v1/subsidiaries
{ "data": [ { "id": 1, "name": "…", "description": "…",
              "openingHours": { "1": [ { "from": "08:00", "to": "12:00" } ] } } ],
  "meta": { "count": 1 } }
```

Stored data only. Whether a branch is open at the moment of the call is not computed —
that depends on the caller's timezone, and the rest of the API returns locale- and
timezone-independent data.

`openingHours` is `null` when nothing is configured; an empty PHP array serialises to
`[]`, which would contradict the object the schema promises. The invoice number pattern
stays out of the payload as internal billing configuration.

New scope `subsidiaries:read`, requiring `ROLE_RESERVATIONS_RO` — the same role as
prices rather than the stricter admin one, since branch names and opening hours are the
least sensitive of the settings data already exposed here.

## Tests

Thirteen unit tests: eight on normalisation and formatting (half-filled ranges dropped,
an empty grid collapsing to "not configured", weekdays outside 1–7 ignored, string keys
from JSON decoding, folding interrupted by a closed day, locale-dependent names) and
five on the API payload. Plus the schema-reachability test above. `OpenApiSpecTest`
covers the new endpoint. Full unit suite green.

Both languages complete, release note added to `docs/release-notes/4.12.0.de.md`.

## Left out, and I would like your read

The issue listed four points; this PR builds two of them. The rest is deliberately not
here — I would rather know whether you want it before building on top of this:

**Dated exceptions** (public holidays, company holidays). A growing dated list belongs in
its own table with a foreign key, plus row management in the branch form along the lines
of `TouristTax/_form.html.twig`, plus a second field in the API payload. Worth it, or is
"closed on the 24th" something an operator writes into a note anyway?

**A free-text hint** ("by arrangement only", a phone number). One nullable column and a
textarea — small, but it overlaps with what a template can already say, so I left it for
you to decide.

If both are wanted, they are one further migration together rather than two.

**Per-weekday output.** `openingHoursFormatted` prints the whole week as one line. A
sibling `getOpeningHoursByWeekdayFormatted()` returning `[1 => '08:00–12:00, 16:00–19:00']`
would let a template name the day itself — `[[ …openingHoursByWeekdayFormatted[1] ]]`, with
`|default('geschlossen')` covering a closed day. Fifteen lines, no migration, and it works
locally. I left it out because the autocomplete would then offer three similar entries side
by side — `openingHours`, `…Formatted`, `…ByWeekdayFormatted` — which is a lot of choice
for the audience this UI is written for. Say the word and it goes in.

## One thing I noticed but did not touch

`TemplateSchemaService` types every public getter that returns neither an entity nor a
collection as `scalar`, arrays included. So `openingHours` — the raw weekday map behind
`openingHoursFormatted` — is offered by the editor's autocomplete beside it as though it
were printable, and a template using it renders the word `Array`.
`reservation1.guestCounts` has had the same trait since 4.11.0, so this is not something
branches introduce.

I left it alone: it is shared infrastructure every template type depends on, and it does
not belong in a pull request about opening hours. Would you rather have an `array` type
in the schema — data-repeat capable, the way the operations providers already declare
theirs by hand — or an attribute that keeps a getter out of the schema altogether? Happy
to do either separately.
